### PR TITLE
fix: patch xlsx dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="0.9.0"></a>
+# 0.9.0 (2024-02-05)
+
+
+### Bug Fixes
+
+* Fixed[#41](https://github.com/securedeveloper/react-data-export/issues/41), Fixed[#55](https://github.com/securedeveloper/react-data-export/issues/55), Fixed[#66](https://github.com/securedeveloper/react-data-export/issues/66), Fixed[#67](https://github.com/securedeveloper/react-data-export/issues/67), Fixed[#68](https://github.com/securedeveloper/react-data-export/issues/68), Fixed[#69](https://github.com/securedeveloper/react-data-export/issues/69), Fixed[#72](https://github.com/securedeveloper/react-data-export/issues/72) ([0144afc](https://github.com/securedeveloper/react-data-export/commit/0144afc))
+* improve types to represent children, fix types to represent ExcelCellData with arrays (as in ex2 - multiDataSet) ([5f0d69d](https://github.com/securedeveloper/react-data-export/commit/5f0d69d))
+* int cells were not supported in dataSet format ([513ae48](https://github.com/securedeveloper/react-data-export/commit/513ae48))
+* package vulnerabilities. ([082947a](https://github.com/securedeveloper/react-data-export/commit/082947a))
+* package vulnerabilities. ([d66eb9e](https://github.com/securedeveloper/react-data-export/commit/d66eb9e))
+* package.json to reduce vulnerabilities ([cfc5ecb](https://github.com/securedeveloper/react-data-export/commit/cfc5ecb))
+* remove package.lock to stabalize ([6e66121](https://github.com/securedeveloper/react-data-export/commit/6e66121))
+* updated package to tempa-xlsx, updated jest test environment and imports. ([b4f03ac](https://github.com/securedeveloper/react-data-export/commit/b4f03ac))
+* **graphite:** move to npm package ([560b2f9](https://github.com/securedeveloper/react-data-export/commit/560b2f9)), closes [issue#41](https://github.com/issue/issues/41)
+
+
+### Features
+
+* add excel data export ([94530e3](https://github.com/securedeveloper/react-data-export/commit/94530e3))
+* add jest support ([ff3a2ba](https://github.com/securedeveloper/react-data-export/commit/ff3a2ba))
+* add react component typings ([25528dd](https://github.com/securedeveloper/react-data-export/commit/25528dd))
+* if the header has style then the style should be used ([855d37a](https://github.com/securedeveloper/react-data-export/commit/855d37a))
+* support col width ([dc6dc60](https://github.com/securedeveloper/react-data-export/commit/dc6dc60))
+* update example with col widths ([4863aaf](https://github.com/securedeveloper/react-data-export/commit/4863aaf))
+
+
+
 <a name="0.8.0"></a>
 # 0.8.0 (2024-02-03)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-data-export",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
   "description": "A set of tools to export dataset from react to different formats.",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "jest": "^23.6.0",
     "jest-environment-node": "22.4.1",
     "nyc": "11.2.1",
+    "patch-package": "^8.0.0",
     "prop-types": "15.6.0",
     "react": "16.0.0",
     "react-dom": "16.0.1",

--- a/package.json
+++ b/package.json
@@ -63,11 +63,12 @@
     "coverage:html": "nyc report --reporter=html",
     "coverage:publish": "nyc report --reporter=lcov | codecov",
     "clean": "rm -rf ./dist && mkdir ./dist",
-    "build": "npm run test && babel src --out-dir dist",
+    "build": "babel src --out-dir dist",
     "build:watch": "babel -w src --out-dir dist",
     "lint": "eslint .",
     "lint:watch": "esw -w lib/**",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "postinstall": "patch-package"
   },
   "commitlint": {
     "extends": [

--- a/patches/tempa-xlsx+0.8.20.patch
+++ b/patches/tempa-xlsx+0.8.20.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/tempa-xlsx/xlsx.js b/node_modules/tempa-xlsx/xlsx.js
+index 6bca3c6..4a999af 100644
+--- a/node_modules/tempa-xlsx/xlsx.js
++++ b/node_modules/tempa-xlsx/xlsx.js
+@@ -12151,7 +12151,7 @@ var XmlNode = (function () {
+     return this;
+   }
+ 
+-  var APOS = "'"; QUOTE = '"'
++  var APOS = "'", QUOTE = '"'
+   var ESCAPED_QUOTE = {  }
+   ESCAPED_QUOTE[QUOTE] = '&quot;'
+   ESCAPED_QUOTE[APOS] = '&apos;'


### PR DESCRIPTION
In strict mode variables must be properly declared. There is a portion in the tempa-xlsx package which declares the `QUOTE` variable incorrectly as `var APOS = "'"; QUOTE = '"'`. 

This PR uses `patch-package` to fix the issue so that:

```js
var APOS = "'"; QUOTE = '"'
```

becomes:

```
var APOS = "'", QUOTE = '"'
```