### PR TITLE
fix: use company managed fork of tempa-xlsx & release 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="0.9.1"></a>
+## [0.9.1](https://github.com/securedeveloper/react-data-export/compare/v0.9.0...v0.9.1) (2024-02-05)
+
+
+### Bug Fixes
+
+* use company managed fork of tempa-xlsx ([c358781](https://github.com/securedeveloper/react-data-export/commit/c358781))
+
+
+
 <a name="0.9.0"></a>
 # 0.9.0 (2024-02-05)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-data-export",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
   "description": "A set of tools to export dataset from react to different formats.",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/securedeveloper/react-data-export#readme",
   "dependencies": {
     "file-saver": "^2.0.5",
-    "tempa-xlsx": "^0.8.20"
+    "tempa-xlsx": "github:cherokee-saas/tempa-xlsx#v0.9.0"
   },
   "devDependencies": {
     "@commitlint/cli": "6.1.3",


### PR DESCRIPTION
Fixes same issue as #3. However, this one does not use patch-package, instead it uses a company-managed tempa-xlsx package https://github.com/cherokee-saas/tempa-xlsx/pull/3